### PR TITLE
Refactor: Integrate SQLite database for task persistence

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.23.3
 require rsc.io/quote v1.5.2
 
 require (
+	github.com/mattn/go-sqlite3 v1.14.28 // indirect
 	golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c // indirect
 	rsc.io/sampler v1.3.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/mattn/go-sqlite3 v1.14.28 h1:ThEiQrnbtumT+QMknw63Befp/ce/nUPgBPMlRFEum7A=
+github.com/mattn/go-sqlite3 v1.14.28/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c h1:qgOY6WgZOaTkIIMiVjBQcw93ERBE4m30iBm00nkL0i8=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 rsc.io/quote v1.5.2 h1:w5fcysjrx7yqtD/aO+QwRjYZOKnaM9Uh2b40tElTs3Y=


### PR DESCRIPTION
This commit refactors the CLI task manager to use a SQLite database instead of in-memory storage. This allows tasks to persist across application sessions.

Changes include:
- Added `github.com/mattn/go-sqlite3` dependency.
- Initialized a SQLite database (`tasks.db`) on startup, creating a `tasks` table if it doesn't exist. The table schema is (id INTEGER PRIMARY KEY, name TEXT, status TEXT).
- Modified all task management functions (add, show, delete, mark in progress, mark done) to perform CRUD operations on the database.
- Updated the `Task` struct to include an `ID` field.
- Replaced `fmt.Scanln` with `bufio.NewReader` for more robust input handling of task names and menu choices, fixing bugs related to truncated input and issues with piped input.
- Removed `ClearScreen` calls as they interfered with non-interactive use and provided limited value.